### PR TITLE
Support template literals in translations file

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,3 +65,35 @@ Your minification step will transform keys like this:
 On average the minified output is between 5% and 10% smaller than the original input, and the runtime
 library is much smaller than other alternatives and even smaller because it can be tree-shaken so only
 the helpers your translations need are included, varying the weight of the library between 1k and just a few bytes.
+
+If you store translations in `*.js` file, you may use template literals (strings with backticks). These strings may span multiple lines in the file.
+
+```js
+export default {
+  notice: `
+    Great to see you again!
+    ... long text ...
+  `
+}
+```
+
+Note: you should not use JavaScript variables and expressions in these template literals. This syntax *is not* supported:
+
+```js
+const name = "Gregory"
+export default {
+  notice: `Hello, ${name}`
+}
+```
+
+It will be better to use interpolations and pass values on call:
+
+```js
+// Translations file.
+export default {
+  notice: `Hello, {name}`
+}
+
+// Page, layout, etc. See `precompile-intl-runtime`.
+$t('notice', {values: {name: 'Gregory'}})
+```

--- a/src/index.js
+++ b/src/index.js
@@ -200,6 +200,11 @@ module.exports = function build(runtimeImportPath = "precompile-intl-runtime") {
             let icuAST = parse(node.value.value, {ignoreTag: true});
             if (icuAST.length === 1 && icuAST[0].type === 0) return;
             node.value = buildFunction(icuAST);
+          } else if (t.isTemplateLiteral(node.value) && node.value.quasis.length == 1) {
+            const quasis_value = node.value.quasis[0].value;
+            let icuAST = parse(quasis_value.raw, {ignoreTag: true});
+            if (icuAST.length === 1 && icuAST[0].type === 0) return;
+            node.value = buildFunction(icuAST);
           }
         },
         VariableDeclarator({ node }) {

--- a/test/fixtures/default/with-template-literals/input.js
+++ b/test/fixtures/default/with-template-literals/input.js
@@ -1,0 +1,11 @@
+export default {
+  plain: `string`,
+  multiline: `
+    string
+  `,
+  with_interpolation: `city {city}`,
+  with_plural: `{cats, plural, one {cat} other {# cats}}`,
+  with_select: `{gender, select, male {he} female {she} other {they}}`,
+  with_backticks: `add \`code\``,
+  with_backticks_and_interpolation: `\`type\` is {type}`
+};

--- a/test/fixtures/default/with-template-literals/output.js
+++ b/test/fixtures/default/with-template-literals/output.js
@@ -1,0 +1,19 @@
+import { __interpolate, __plural, __select } from "precompile-intl-runtime";
+export default {
+  plain: `string`,
+  multiline: `
+    string
+  `,
+  with_interpolation: city => `city ${__interpolate(city)}`,
+  with_plural: cats => __plural(cats, {
+    o: "cat",
+    h: `${cats} cats`
+  }),
+  with_select: gender => __select(gender, {
+    male: "he",
+    female: "she",
+    other: "they"
+  }),
+  with_backticks: `add \`code\``,
+  with_backticks_and_interpolation: type => `\`type\` is ${__interpolate(type)}`
+};

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -80,3 +80,10 @@ it("flattens the object, joining keys with a dot", () => {
   const { code } = babel.transform(input, { plugins: [plugin] });
   expect(code).toBe(output);
 });
+
+it("works with template literals", () => {
+  let input = fs.readFileSync(path.join('test', 'fixtures', 'default', 'with-template-literals', 'input.js'), 'UTF8');
+  let output = fs.readFileSync(path.join('test', 'fixtures', 'default', 'with-template-literals', 'output.js'), 'UTF8');
+  const { code } = babel.transform(input, { plugins: [plugin] });
+  expect(code).toBe(output);
+});


### PR DESCRIPTION
Template literals may be useful for multiline strings in translations file.

```js
export default {
  hello_world: `Hello, {name}.
    I want to show you the magic!
  `
}
```

The code above will be transformed to:

```js
import { __interpolate } from "precompile-intl-runtime";
export default {
  hello_world: name => `Hello, ${__interpolate(name)}.
    I want to show you the magic!
  `
}
```

Embedded variables and expressions are not supported.